### PR TITLE
[chore](ci): bump version to 1.6.0

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// VERSION version
-	VERSION = "1.5.5"
+	VERSION = "1.6.0"
 )
 
 var (

--- a/proxy/CHANGELOG.md
+++ b/proxy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Overlord-proxy
 
+## Version 1.6.0
+1. add migrate tools named [anzi](https://github.com/bilibili/overlord/blob/master/doc/wiki-cn/tools.md)
+2. add cluster manager tools [enri](https://github.com/bilibili/overlord/blob/master/doc/wiki-cn/enri.md)
+3. fixed overlord panic when all cluster seed nodes down
+4. add back prometheus monitor metrics
+
 ## Version 1.5.5
 1. change pinger as long connection.
 


### PR DESCRIPTION
1. add migrate tools named [anzi](https://github.com/bilibili/overlord/blob/master/doc/wiki-cn/tools.md)
2. add cluster manager tools [enri](https://github.com/bilibili/overlord/blob/master/doc/wiki-cn/enri.md)
3. fixed overlord panic when all cluster seed nodes down
4. add back prometheus monitor metrics