### PR TITLE
fixed：后续新任务状态更新不生效问题。

### DIFF
--- a/platform/api/dao/job.go
+++ b/platform/api/dao/job.go
@@ -83,11 +83,13 @@ func (d *Dao) WatchJob(ctx context.Context) (j chan *model.Job) {
 	key, _ := d.e.WatchOn(ctx, etcd.JobsDir, etcd.ActionSet, etcd.ActionCreate)
 	j = make(chan *model.Job)
 	go func() {
-		node := <-key
-		pre, id := filepath.Split(node.Key)
-		_, group := filepath.Split(pre[:len(pre)-1])
-		job := &model.Job{ID: fmt.Sprintf("%s.%s", group, id), Param: node.Value}
-		j <- job
+		for {
+			node := <-key
+			pre, id := filepath.Split(node.Key)
+			_, group := filepath.Split(pre[:len(pre)-1])
+			job := &model.Job{ID: fmt.Sprintf("%s.%s", group, id), Param: node.Value}
+			j <- job
+		}
 	}()
 	return
 }


### PR DESCRIPTION
api-server 启动后，只有第一个新任务能及时更新job_detail状态，后续新任务状态更新不生效（虽然再次重启能解决）。