### PR TITLE
fixed：destory action hold onto offers

### DIFF
--- a/platform/mesos/scheduler.go
+++ b/platform/mesos/scheduler.go
@@ -498,7 +498,7 @@ func (s *Scheduler) dispatchCluster(t job.Job, num int, mem, cpu float64, offers
 		jobChunks = newChunk
 		chunks = append(chunks, newChunk...)
 	case job.OpDestroy:
-		s.destroyCluster(t)
+		s.destroyCluster(t, offers)
 		return
 	case job.OpRestart:
 		s.restartNode(t, offers)
@@ -580,7 +580,7 @@ func (s *Scheduler) dispatchSingleton(t job.Job, offers []ms.Offer) (err error) 
 		}
 		jobDist = dist
 	case job.OpDestroy:
-		s.destroyCluster(t)
+		s.destroyCluster(t, offers)
 		return
 	case job.OpScale:
 		var (
@@ -677,7 +677,7 @@ func (s *Scheduler) dispatchSingleton(t job.Job, offers []ms.Offer) (err error) 
 	return
 }
 
-func (s *Scheduler) destroyCluster(t job.Job) {
+func (s *Scheduler) destroyCluster(t job.Job, offers []ms.Offer) {
 	var (
 		ctx = context.Background()
 	)

--- a/platform/mesos/scheduler.go
+++ b/platform/mesos/scheduler.go
@@ -9,15 +9,13 @@ import (
 	"strings"
 	"time"
 
-	
-	"overlord/platform/chunk"
 	"overlord/pkg/etcd"
 	"overlord/pkg/log"
 	"overlord/pkg/types"
+	"overlord/platform/chunk"
 	"overlord/platform/job"
 	"overlord/platform/job/create"
-	
-	"github.com/pkg/errors"
+
 	pb "github.com/golang/protobuf/proto"
 	ms "github.com/mesos/mesos-go/api/v1/lib"
 	"github.com/mesos/mesos-go/api/v1/lib/encoding/codecs"
@@ -26,10 +24,11 @@ import (
 	"github.com/mesos/mesos-go/api/v1/lib/extras/scheduler/eventrules"
 	mstore "github.com/mesos/mesos-go/api/v1/lib/extras/store"
 	"github.com/mesos/mesos-go/api/v1/lib/httpcli"
-	"github.com/mesos/mesos-go/api/v1/lib/httpcli/httpsched"	
+	"github.com/mesos/mesos-go/api/v1/lib/httpcli/httpsched"
 	"github.com/mesos/mesos-go/api/v1/lib/scheduler"
 	"github.com/mesos/mesos-go/api/v1/lib/scheduler/calls"
 	"github.com/mesos/mesos-go/api/v1/lib/scheduler/events"
+	"github.com/pkg/errors"
 	cli "go.etcd.io/etcd/client"
 )
 
@@ -158,7 +157,6 @@ func (s *Scheduler) buildFrameworkInfo() *ms.FrameworkInfo {
 	return frameworkInfo
 }
 
-
 func (s *Scheduler) buildEventHandle() events.Handler {
 	logger := controller.LogEvents(eventLog)
 	return eventrules.New().Handle(events.Handlers{
@@ -232,18 +230,22 @@ func (s *Scheduler) resourceOffers() events.HandlerFunc {
 		}
 		// if there don't have any task,decline all offers and suppress offer envent.
 		// until task comming and call revive to schedule new workloads by taskevent.
-		ofid := make([]ms.OfferID, len(offers))
-		for _, offer := range offers {
-			ofid = append(ofid, offer.ID)
-		}
-		decli := calls.Decline(ofid...)
-		// TODO: deal with error
-		_ = calls.CallNoData(ctx, s.cli, decli)
-		suppress := calls.Suppress()
-		// TODO: deal with error
-		_ = calls.CallNoData(ctx, s.cli, suppress)
+		s.declineAndSuppress(offers, ctx)
 		return nil
 	}
+}
+
+func (s *Scheduler) declineAndSuppress(offers []ms.Offer, ctx context.Context) {
+	ofid := make([]ms.OfferID, len(offers))
+	for _, offer := range offers {
+		ofid = append(ofid, offer.ID)
+	}
+	decli := calls.Decline(ofid...)
+	// TODO: deal with error
+	_ = calls.CallNoData(ctx, s.cli, decli)
+	suppress := calls.Suppress()
+	// TODO: deal with error
+	_ = calls.CallNoData(ctx, s.cli, suppress)
 }
 
 func (s *Scheduler) tryRecovery(t ms.TaskID, offers []ms.Offer, force bool) (err error) {
@@ -679,6 +681,9 @@ func (s *Scheduler) destroyCluster(t job.Job) {
 	var (
 		ctx = context.Background()
 	)
+	// destroy didn't need to offers，should decline it immediately
+	s.declineAndSuppress(offers, ctx)
+
 	ci, err := s.getInfoFromEtcd(ctx, t.Name)
 	if err != nil {
 		log.Errorf("get info fail err %v", err)


### PR DESCRIPTION
> Do not hold onto offers: If an offer cannot be used, decline it immediately. Otherwise the resources cannot be offered to other schedulers and the scheduler itself will receive fewer additional offers
[https://mesos.apache.org/documentation/latest/app-framework-development-guide/#multi-scheduler-scalability](url) 

after destory action, scheduler can't create new cluster because of holding onto offers.