### PR TITLE
copy data rather than assignment in WithReq

### DIFF
--- a/proxy/proto/memcache/proxy_conn.go
+++ b/proxy/proto/memcache/proxy_conn.go
@@ -281,14 +281,14 @@ func WithReq(m *proto.Message, rtype RequestType, key []byte, data []byte) {
 	if req == nil {
 		req := GetReq()
 		req.respType = rtype
-		req.key = key
-		req.data = data
+		req.key = key[:]
+		req.data = data[:]
 		m.WithRequest(req)
 	} else {
 		mcreq := req.(*MCRequest)
 		mcreq.respType = rtype
-		mcreq.key = key
-		mcreq.data = data
+		mcreq.key = key[:]
+		mcreq.data = data[:]
 	}
 }
 


### PR DESCRIPTION
avoid bad memory reference when buffer reader reseted