### PR TITLE
fix:when cursor < 0 && cursor > ^int32(^uint32(0)>>1),idx < 0

### DIFF
--- a/proxy/slowlog/slowlog.go
+++ b/proxy/slowlog/slowlog.go
@@ -13,7 +13,7 @@ const slowlogMaxCount = 1024
 func newStore(name string) *Store {
 	return &Store{
 		name:   name,
-		cursor: -1,
+		cursor: 0,
 		msgs:   make([]atomic.Value, slowlogMaxCount),
 	}
 }
@@ -33,7 +33,7 @@ func (s *Store) Record(msg *proto.SlowlogEntry) {
 
 	for {
 		if atomic.CompareAndSwapUint32(&s.cursor, s.cursor, s.cursor+1) {
-			idx := s.cursor % slowlogMaxCount
+			idx := (s.cursor - 1) % slowlogMaxCount
 			s.msgs[idx].Store(msg)
 			if fh != nil {
 				fh.save(s.name, msg)

--- a/proxy/slowlog/slowlog.go
+++ b/proxy/slowlog/slowlog.go
@@ -21,7 +21,7 @@ func newStore(name string) *Store {
 // Store is the collector of slowlog
 type Store struct {
 	name   string
-	cursor int32
+	cursor uint32
 	msgs   []atomic.Value
 }
 
@@ -32,7 +32,7 @@ func (s *Store) Record(msg *proto.SlowlogEntry) {
 	}
 
 	for {
-		if atomic.CompareAndSwapInt32(&s.cursor, s.cursor, s.cursor+1) {
+		if atomic.CompareAndSwapUint32(&s.cursor, s.cursor, s.cursor+1) {
 			idx := s.cursor % slowlogMaxCount
 			s.msgs[idx].Store(msg)
 			if fh != nil {

--- a/proxy/slowlog/slowlog_test.go
+++ b/proxy/slowlog/slowlog_test.go
@@ -1,0 +1,49 @@
+package slowlog
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"sync/atomic"
+	"testing"
+)
+
+//in slowlog cursorInt32 init val is -1
+var cursorInt32 int32
+
+//in slowlog cursorUint32 init val is 0
+var cursorUint32 uint32
+
+func TestRecordWithCursorUint32(t *testing.T) {
+	//now cursorUint32 is uint32's max val
+	cursorUint32 = ^uint32(0)
+	idxOk := true
+	for i := 1; i < 10; i++ {
+		if atomic.CompareAndSwapUint32(&cursorUint32, cursorUint32, cursorUint32+1) {
+			idx := (cursorUint32 - 1) % slowlogMaxCount
+			fmt.Fprintf(os.Stdout, "%d mod 1024 = %d\n", cursorUint32-1, idx)
+			if idx < 0 {
+				idxOk = false
+				break
+			}
+		}
+	}
+	assert.True(t, idxOk)
+}
+
+func TestRecordWithCursorInt32(t *testing.T) {
+	//now cursorInt32 is int32's max val
+	cursorInt32 = int32(^uint32(0) >> 1)
+	idxOk := true
+	for i := 1; i < 10; i++ {
+		if atomic.CompareAndSwapInt32(&cursorInt32, cursorInt32, cursorInt32+1) {
+			idx := cursorInt32 % slowlogMaxCount
+			if idx < 0 {
+				fmt.Fprintf(os.Stdout, "%d mod 1024 = %d\n", cursorInt32, idx)
+				idxOk = false
+				break
+			}
+		}
+	}
+	assert.False(t, idxOk)
+}


### PR DESCRIPTION
panic: runtime error: index out of range [-1023]